### PR TITLE
More love for UA Patch players

### DIFF
--- a/src/main/java/emu/grasscutter/server/http/dispatch/RegionHandler.java
+++ b/src/main/java/emu/grasscutter/server/http/dispatch/RegionHandler.java
@@ -143,11 +143,22 @@ public final class RegionHandler implements Router {
 
         if( versionName.contains("2.7.5") || versionName.contains("2.8.")) {
             try {
+                QueryCurrentRegionEvent event = new QueryCurrentRegionEvent(regionData); event.call();
+
+                if (GAME_OPTIONS.uaPatchCompatible) {
+                    // More love for UA Patch players
+                    response.json(Map.of(
+                        "content",
+                        event.getRegionInfo(),
+                        "sign",
+                        "TW9yZSBsb3ZlIGZvciBVQSBQYXRjaCBwbGF5ZXJz"
+                    ));
+                    return;
+                }
+
                 String key_id = request.query("key_id");
                 Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
                 cipher.init(Cipher.ENCRYPT_MODE, key_id.equals("3") ? Crypto.CUR_OS_ENCRYPT_KEY : Crypto.CUR_CN_ENCRYPT_KEY);
-
-                QueryCurrentRegionEvent event = new QueryCurrentRegionEvent(regionData); event.call();
                 var regionInfo = Utils.base64Decode(event.getRegionInfo());
 
                 //Encrypt regionInfo in chunks

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerTokenReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerTokenReq.java
@@ -1,6 +1,7 @@
 package emu.grasscutter.server.packet.recv;
 
 import static emu.grasscutter.Configuration.ACCOUNT;
+import static emu.grasscutter.Configuration.GAME_OPTIONS;
 
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.database.DatabaseHelper;
@@ -14,6 +15,7 @@ import emu.grasscutter.server.event.game.PlayerCreationEvent;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.game.GameSession.SessionState;
 import emu.grasscutter.server.packet.send.PacketGetPlayerTokenRsp;
+import emu.grasscutter.utils.ByteHelper;
 import emu.grasscutter.utils.Crypto;
 import emu.grasscutter.utils.Utils;
 
@@ -99,6 +101,21 @@ public class HandlerGetPlayerTokenReq extends PacketHandler {
 
         // Only >= 2.7.50 has this
         if (req.getKeyId() > 0) {
+            if (GAME_OPTIONS.uaPatchCompatible) {
+                // More love for ua patch plz 😭
+
+                byte[] clientBytes = Utils.base64Decode(req.getClientSeed());
+                byte[] seed = ByteHelper.longToBytes(Crypto.ENCRYPT_SEED);
+                Crypto.xor(clientBytes, seed);
+
+                String base64str = Utils.base64Encode(clientBytes);
+
+                int keyId = req.getKeyId();
+
+                session.send(new PacketGetPlayerTokenRsp(session, keyId, base64str));
+                return;
+            }
+
             Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
             cipher.init(Cipher.DECRYPT_MODE, Crypto.CUR_SIGNING_KEY);
 

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketGetPlayerTokenRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketGetPlayerTokenRsp.java
@@ -75,4 +75,30 @@ public class PacketGetPlayerTokenRsp extends BasePacket {
 
         this.setData(p.toByteArray());
     }
+
+    public PacketGetPlayerTokenRsp(GameSession session, int keyId, String encryptedSeed) {
+        super(PacketOpcodes.GetPlayerTokenRsp, true);
+
+        this.setUseDispatchKey(true);
+
+        GetPlayerTokenRsp p = GetPlayerTokenRsp.newBuilder()
+            .setUid(session.getPlayer().getUid())
+            .setToken(session.getAccount().getToken())
+            .setAccountType(1)
+            .setIsProficientPlayer(session.getPlayer().getAvatars().getAvatarCount() > 0) // Not sure where this goes
+            .setSecretKeySeed(Crypto.ENCRYPT_SEED)
+            .setSecurityCmdBuffer(ByteString.copyFrom(Crypto.ENCRYPT_SEED_BUFFER))
+            .setPlatformType(3)
+            .setChannelId(1)
+            .setCountryCode("US")
+            .setClientVersionRandomKey("c25-314dd05b0b5f")
+            .setRegPlatform(3)
+            .setClientIpStr(session.getAddress().getAddress().getHostAddress())
+            .setUnk2800BPJOBLNCBEI(keyId) // key id
+            .setEncryptedSeed(encryptedSeed)
+            .setSeedSignature("bm90aGluZyBoZXJl")
+            .build();
+
+        this.setData(p.toByteArray());
+    }
 }

--- a/src/main/java/emu/grasscutter/utils/ByteHelper.java
+++ b/src/main/java/emu/grasscutter/utils/ByteHelper.java
@@ -1,0 +1,24 @@
+package emu.grasscutter.utils;
+
+public class ByteHelper {
+    public static byte[] changeBytes(byte[] a) {
+        byte[] b = new byte[a.length];
+        for (int i = 0; i < a.length; i++) {
+            b[i] = a[a.length - i - 1];
+        }
+        return b;
+    }
+
+    public static byte[] longToBytes(long x) {
+        byte[] bytes = new byte[8];
+        bytes[0] = (byte) (x >> 56);
+        bytes[1] = (byte) (x >> 48);
+        bytes[2] = (byte) (x >> 40);
+        bytes[3] = (byte) (x >> 32);
+        bytes[4] = (byte) (x >> 24);
+        bytes[5] = (byte) (x >> 16);
+        bytes[6] = (byte) (x >> 8);
+        bytes[7] = (byte) (x);
+        return bytes;
+    }
+}

--- a/src/main/java/emu/grasscutter/utils/ConfigContainer.java
+++ b/src/main/java/emu/grasscutter/utils/ConfigContainer.java
@@ -211,6 +211,7 @@ public class ConfigContainer {
             public int cap = 160;
             public int rechargeTime = 480;
         }
+        public boolean uaPatchCompatible = false;
     }
 
     public static class JoinOptions {


### PR DESCRIPTION
## Description

A `uaPatchCompatible` configuration option is provided to enable support for UA patches, but the two cannot co-exist (perhaps one day in the future I'll come up with a better solution).

Before:

![before](https://user-images.githubusercontent.com/47273265/178436480-3c4546c4-d7ba-40ef-94ab-95d4a1d0eca6.png)

After enabling:

![after](https://user-images.githubusercontent.com/47273265/178436551-a4d98af4-5364-459f-9399-d3a3ac027970.png)

## Issues fixed by this PR

* Eases the pain of UA Patch users who can't play

## Type of changes

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.