### PR TITLE
Password login for UA Patch users

### DIFF
--- a/src/main/java/emu/grasscutter/auth/DefaultAuthenticators.java
+++ b/src/main/java/emu/grasscutter/auth/DefaultAuthenticators.java
@@ -105,19 +105,24 @@ public final class DefaultAuthenticators {
             String decryptedPassword = "";
 
             // Get Password
-            try {
-                byte[] key = FileUtils.readResource("/keys/auth_private-key.der");
-                PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(key);
-                KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-                RSAPrivateKey private_key = (RSAPrivateKey) keyFactory.generatePrivate(keySpec);
+            if (GAME_OPTIONS.uaPatchCompatible) {
+                // Make sure your patch can send passwords in plain text
+                decryptedPassword = request.getPasswordRequest().password;
+            } else {
+                try {
+                    byte[] key = FileUtils.readResource("/keys/auth_private-key.der");
+                    PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(key);
+                    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+                    RSAPrivateKey private_key = (RSAPrivateKey) keyFactory.generatePrivate(keySpec);
 
-                Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
+                    Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
 
-                cipher.init(Cipher.DECRYPT_MODE, private_key);
+                    cipher.init(Cipher.DECRYPT_MODE, private_key);
 
-                decryptedPassword = new String(cipher.doFinal(Utils.base64Decode(request.getPasswordRequest().password)), StandardCharsets.UTF_8);
-            } catch (Exception ignored) {
-                ignored.printStackTrace();
+                    decryptedPassword = new String(cipher.doFinal(Utils.base64Decode(request.getPasswordRequest().password)), StandardCharsets.UTF_8);
+                } catch (Exception ignored) {
+                    ignored.printStackTrace();
+                }
             }
 
             if (decryptedPassword == null) {


### PR DESCRIPTION
## Description

Please ensure that your patch can ensure that the password is sent in plaintext.

## Issues fixed by this PR

- Ease the pain of UA Patch players not being able to use password login

## Type of changes

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.